### PR TITLE
Adding Centos 8 stream container support, Fix #4

### DIFF
--- a/Dockerfile.centos-stream8
+++ b/Dockerfile.centos-stream8
@@ -1,0 +1,10 @@
+FROM quay.io/centos/centos:stream8
+LABEL maintainer='Gerard Braad <me@gbraad.nl>' \
+    authors="Bala <srbala@gmail.com>"
+
+RUN dnf update -y && dnf install -y podman crun && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.* && \
+    cp /usr/share/containers/containers.conf /etc/containers/containers.conf && \
+    sed -i '/^# cgroup_manager = "systemd"/ a cgroup_manager = "cgroupfs"' /etc/containers/containers.conf && \
+    sed -i '/^# events_logger = "journald"/ a events_logger = "file"' /etc/containers/containers.conf && \
+    sed -i '/^driver = "overlay"/ c\driver = "vfs"' /etc/containers/storage.conf

--- a/README.md
+++ b/README.md
@@ -27,4 +27,10 @@ $ docker build -t pind-centos - < Dockerfile.centos
 $ docker run -it --privileged --rm pind-centos podman ps
 ```
 
-Note: this image does currently not work as expected.
+CentOS 8 Stream
+---------------
+
+```
+$ docker build -t pind-centos-stream8 - < Dockerfile.centos-stream8
+$ docker run -it --privileged --rm pind-centos-stream8 podman ps
+```


### PR DESCRIPTION
Since CentOS will not get any updates beyond 8.3, Stream container would be good option continued support 2021 and byeond.